### PR TITLE
Support namespace aliases

### DIFF
--- a/src/Neutron/Silex/Provider/MongoDBODMServiceProvider.php
+++ b/src/Neutron/Silex/Provider/MongoDBODMServiceProvider.php
@@ -96,6 +96,11 @@ class MongoDBODMServiceProvider implements ServiceProviderInterface
                         throw new \InvalidArgumentException(sprintf('"%s" is not a recognized driver', $document['type']));
                         break;
                 }
+
+                // add namespace alias
+                if (isset($document['alias'])) {
+                    $config->addDocumentNamespace($document['alias'], $document['namespace']);
+                }
             }
 
             if ($usingAnnotations) {


### PR DESCRIPTION
Sets aliases for document namespaces. Usage: $app['doctrine.odm.mongodb.dm']->find('alias:Document', $id);
